### PR TITLE
Fix/RSS-ECOMM-1_25:  delete isProd variable at webpack config 

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -13,7 +13,6 @@ interface EnvVar {
 
 module.exports = (env: EnvVar) => {
   const isDev = env.mode === 'development';
-  const isProd = env.mode === 'production';
 
   const config: Configuration = {
     mode: env.mode ?? 'development',
@@ -59,7 +58,7 @@ module.exports = (env: EnvVar) => {
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, 'public', 'index.html'),
       }),
-      isProd &&
+      !isDev &&
         new MiniCssExtractPlugin({
           filename: '[name].[contenthash:8].css',
           chunkFilename: '[name].[contenthash:8].css',


### PR DESCRIPTION
**Task link**
[sprint2](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%232.md)

**Date**
Done 07.05.2024 / deadline 21.05.2024

**Description**
 - [x] delete isProd variable at webpack config 