### PR TITLE
feat/RSS-ECOMM-2_06: add redirect logged-in users to the main page from the login page

### DIFF
--- a/src/features/LoginUser/ui/LoginForm.tsx
+++ b/src/features/LoginUser/ui/LoginForm.tsx
@@ -7,22 +7,29 @@ import { useAppDispatch } from 'shared/lib/hooks/useAppDispatch/useAppDispatch';
 import './LoginForm.css';
 import { useAppSelector } from 'shared/lib/hooks/useAppSelect/useAppSelect';
 import { Link, useNavigate } from 'react-router-dom';
-import { passwordFlow, getAccessToken, setUserId } from 'entities/User';
+import { passwordFlow, getAccessToken, setUserId, getUserIsLoginedStatus } from 'entities/User';
 import { requestLogin } from '../model/services/requestLogin';
 import { setNotificationMessage } from 'entities/NotificationTool';
 import { getLoginCustomerId, getLoginError, getLoginResponseId } from '../model/selectors/loginSelectors';
+import { Paths } from 'shared/types';
 
 type LoginData = { email: string; password: string };
 
 const LoginForm: FC = () => {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const accessToken = useAppSelector(getAccessToken);
   const customerId = useAppSelector(getLoginCustomerId);
   const error = useAppSelector(getLoginError);
   const responeId = useAppSelector(getLoginResponseId);
+  const isLogined = useAppSelector(getUserIsLoginedStatus);
+
   const [prevResponeId, setprevResponeId] = useState(responeId);
-  const navigate = useNavigate();
   const [loginData, setLoginData] = useState<LoginData>();
+
+  useEffect(() => {
+    if (isLogined) navigate(Paths.start);
+  }, [isLogined]);
 
   useEffect(() => {
     if (customerId && loginData) {
@@ -34,7 +41,6 @@ const LoginForm: FC = () => {
         }),
       );
       dispatch(passwordFlow({ username: email, password }));
-      navigate('/');
     }
   }, [customerId, dispatch]);
 


### PR DESCRIPTION
**Task link**
[RSS-ECOMM-2_06](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_06.md)

**Date**
Done 17.05.2024 / deadline 21.05.2024

**Description**
 - [x] Authenticated users who attempt to visit the login page are automatically redirected to the main page.
 - [x] The URL in the address bar is changed to the main page's URL for authenticated users redirected from the login page.
 - [x] Redirection maintains the user's authentication state during the process.
 - [x] Proper handling of navigation and user experience during redirection, including updating browser history.