### PR TITLE
fix/RSS-ECOMM-2_25: add autocomplete attribute on inputs with type 'password'

### DIFF
--- a/src/features/LoginUser/ui/LoginForm.tsx
+++ b/src/features/LoginUser/ui/LoginForm.tsx
@@ -100,6 +100,7 @@ const LoginForm: FC = () => {
             prefix={<LockOutlined className="site-form-item-icon" />}
             type="password"
             placeholder="Password"
+            autoComplete="on"
           />
         </Form.Item>
         <Form.Item>

--- a/src/features/RegistrationUser/ui/RegistrationForm.tsx
+++ b/src/features/RegistrationUser/ui/RegistrationForm.tsx
@@ -154,7 +154,7 @@ const RegistrationForm: FC = () => {
               <Input placeholder="example@email.com" />
             </Form.Item>
             <Form.Item name="password" label="Password" required rules={checkPassword()}>
-              <Input.Password />
+              <Input.Password autoComplete="on" />
             </Form.Item>
             <Form.Item
               name="confirm"
@@ -163,7 +163,7 @@ const RegistrationForm: FC = () => {
               dependencies={['password']}
               rules={checkConfirmPassword()}
             >
-              <Input.Password />
+              <Input.Password autoComplete="on" />
             </Form.Item>
             <Form.Item name="firstName" label="First name" required rules={checkInput('First name')}>
               <Input />


### PR DESCRIPTION
**Task link**
[Sprint-2](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint%232.md)

**Date**
Done 19.05.2024 / deadline 21.05.2024

**Description**
 - [x] add autocomplete attribute on inputs with type 'password' (fix warning at Chrome console )