### PR TITLE
fix/RSS-ECOMM-2_26: fix regExp for containing letters and space

### DIFF
--- a/src/shared/lib/checkValid/validationRules/checkContainOnlyLetters.ts
+++ b/src/shared/lib/checkValid/validationRules/checkContainOnlyLetters.ts
@@ -1,4 +1,4 @@
 export function checkContainOnlyLetters(str: string): boolean {
-  const regex = /^[A-Za-z]+$/;
+  const regex = /^(?!\s)[A-Za-z\s]+$/;
   return !regex.test(str);
 }


### PR DESCRIPTION
**Task link**
[ECOMM-2_09](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_09.md)

**Date**
Done 20.05.2024 / deadline 21.05.2024

**Description**
 - [x] add rule for allowed space symbol at names, surnames and cities name 