### PR TITLE
feat/RSS-ECOMM-4_22: implement route for about us page

### DIFF
--- a/src/app/providers/routerProvider/config/rootRouter.tsx
+++ b/src/app/providers/routerProvider/config/rootRouter.tsx
@@ -7,6 +7,7 @@ import { Profile } from 'pages/profile/Profile';
 import { Registration } from 'pages/registration/Registration';
 import { Paths } from 'shared/types';
 import { Cart } from 'pages/cart/Cart';
+import { AboutUs } from 'pages/about-us/AboutUs';
 
 export interface Router {
   path: Paths;
@@ -49,5 +50,9 @@ export const rootRouter: Router[] = [
   {
     path: Paths.cart,
     element: <Cart />,
+  },
+  {
+    path: Paths.about,
+    element: <AboutUs />,
   },
 ];

--- a/src/pages/about-us/AboutUs.module.css
+++ b/src/pages/about-us/AboutUs.module.css
@@ -1,0 +1,4 @@
+.cover {
+  display: flex;
+  flex-grow: 1;
+}

--- a/src/pages/about-us/AboutUs.tsx
+++ b/src/pages/about-us/AboutUs.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import style from './AboutUs.module.css';
+
+export const AboutUs: FC = () => {
+  return (
+    <>
+      <div className={style.cover}>
+        <h2>About us</h2>
+      </div>
+    </>
+  );
+};

--- a/src/shared/types/routerTypes.ts
+++ b/src/shared/types/routerTypes.ts
@@ -7,5 +7,6 @@ export enum Paths {
   product = 'catalog/:productKey',
   profile = 'profile',
   cart = 'cart',
+  about = 'about',
   notFound = '*',
 }

--- a/src/widgets/Header/ui/Header.tsx
+++ b/src/widgets/Header/ui/Header.tsx
@@ -13,6 +13,7 @@ import {
   LoginOutlined,
   ProductOutlined,
   ShoppingCartOutlined,
+  TeamOutlined,
   UserOutlined,
 } from '@ant-design/icons';
 import { Tooltip } from 'antd';
@@ -39,6 +40,16 @@ const links: LinkOfPage[] = [
       <Link className="link-profile" to={Paths.catalog}>
         <Tooltip title="catalog">
           <ProductOutlined style={{ fontSize: '2rem' }} />
+        </Tooltip>
+      </Link>
+    ),
+  },
+  {
+    key: Paths.about,
+    label: (
+      <Link className="link-profile" to={Paths.about}>
+        <Tooltip title="about us">
+          <TeamOutlined style={{ fontSize: '2rem' }} />
         </Tooltip>
       </Link>
     ),


### PR DESCRIPTION
**Task link**
[RSS-ECOMM-4_22](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_22.md)

**Date**
Done 07.06.2024 / deadline 18.06.2024

**Description**
 - [x] add `about us` button at header
 - [x] implement route for about us page